### PR TITLE
Image content provider

### DIFF
--- a/backend/eureka/eureka/settings.py
+++ b/backend/eureka/eureka/settings.py
@@ -44,7 +44,6 @@ INSTALLED_APPS = [
 
     'crispy_forms',
     'ckeditor',
-    'captcha',
 
     'rest_framework',
 

--- a/backend/image/COPYING
+++ b/backend/image/COPYING
@@ -1,0 +1,20 @@
+Copyright (c) Florent Le Coz
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+claim that you wrote the original software. If you use this software
+in a product, an acknowledgment in the product documentation would be
+appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+distribution.

--- a/backend/image/Dockerfile
+++ b/backend/image/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.4-alpine
+ADD . /code
+WORKDIR /code
+RUN pip install -r requirements.txt
+CMD ["python", "app.py"]

--- a/backend/image/Dockerfile
+++ b/backend/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4-alpine
+FROM python:3.4
 ADD . /code
 WORKDIR /code
 RUN pip install -r requirements.txt

--- a/backend/image/LICENSE_PLZIMG.txt
+++ b/backend/image/LICENSE_PLZIMG.txt
@@ -1,0 +1,99 @@
+
+This package contains code from plzimg, below is the licensing terms for that.
+
+---
+
+     _
+ _ __ | |___(_)_ __ ___   __ _
+| '_ \| |_  / | '_ ` _ \ / _` |
+| |_) | |/ /| | | | | | | (_| |
+| .__/|_/___|_|_| |_| |_|\__, |
+|_|                      |___/
+
+Homepage:       http://dev.louiz.org/projects/plzimg
+
+Plzimg is a very simple and lightweight web application, without any
+database, that lets users upload their images. It is developed in python3
+and uses the Flask framework.
+
+It doesn't provide any way to search for uploaded images, or even to list
+them.  It is not possible to remove, tag or describe the images.  Just
+upload the image, use the URL somewhere, do not lose it, and that’s it.
+
+
+================
+    Install
+================
+You need python3-flask and python3-pillow (to resize the uploaded images).
+Simply create two directories, one for each size of image:
+o/ for the original images
+s/ for the resized images
+
+You can test the application by running
+
+$ python3 app.py
+
+This will start a test server running on port 5000, but it is not suitable
+for production.
+If you want to deploy it on your web server, please refer to one of the
+methods described on http://flask.pocoo.org/docs/deploying/
+
+Here is, as an example, my own configuration, using uwsgi and nginx.  As an
+additional feature, it provides compatibility with the URLs of the pix
+software that can be found at http://pix.toile-libre.org/
+It requires an additional directory, m/, that is filled with the smallest
+images (used for the thumbs).
+
+$ cat /etc/uwsgi.d/pix.ini
+[uwsgi]
+socket = 127.0.0.1:3032
+master = true
+plugin = python3
+chdir = /home/louiz/plzimg
+module = app:app
+processes = 4
+
+$ cat /etc/nginx/sites/pix.louiz.org.conf
+server
+{
+        listen          80;
+        server_name     pix.louiz.org;
+        client_max_body_size 100m;
+
+        location @pix {
+            include        uwsgi_params;
+            uwsgi_pass     127.0.0.1:3032;
+        }
+
+        location / {
+
+            # Compatibility with pix.toile-libre.org URLs
+            rewrite ^/upload/original/(.*)$ /o/$1 permanent;
+            rewrite ^/upload/img/(.*)$ /s/$1 permanent;
+            rewrite ^/upload/thumb/(.*)$ /m/$1 permanent;
+            rewrite ^/\?img=(.*)$ /$1 permanent;
+
+            root /home/louiz/plzimg/;
+
+            try_files   $uri @pix;
+        }
+}
+
+================
+    Authors
+================
+Florent Le Coz (louiz’) <louiz@louiz.org>
+
+=================
+ Contact/Support
+=================
+Report a bug:        http://dev.louiz.org/projects/plzimg/issues/new
+
+=================
+    Licence
+=================
+Plzimg is Free Software.
+(learn more: http://www.gnu.org/philosophy/free-sw.html)
+
+Plzimg is released under the zlib license.
+Please read the COPYING file for details.

--- a/backend/image/app.py
+++ b/backend/image/app.py
@@ -58,4 +58,4 @@ def o(filename):
     return send_file('o/'+filename, mimetype='image/' + get_extension(filename))
 
 if __name__ == "__main__":
-    app.run(debug=False)
+    app.run(debug=False, host='0.0.0.0', port=5000)

--- a/backend/image/app.py
+++ b/backend/image/app.py
@@ -1,0 +1,61 @@
+from PIL import Image
+
+import random
+import string
+import flask
+import os
+import io
+import re
+
+from flask import send_file
+
+app = flask.Flask(__name__)
+app.config["UPLOAD_FOLDER"] = "./"
+app.config["ALLOWED_IMG_EXTENSIONS"] = ('.png', '.jpeg', '.jpg', '.svg', '.gif', '.bmp')
+
+def get_filename(ext):
+    res = []
+    for i in range(20):
+        res.append(random.choice(string.ascii_letters))
+    return ''.join(res) + ext
+
+
+def get_extension(filename):
+    return re.sub('^.+/.', '', filename)
+
+@app.route('/', methods=["POST"])
+def post_img():
+    request = flask.request
+    file = request.files['file']
+    if not file.filename:
+        return "olmadi yar"
+    name, ext = os.path.splitext(file.filename)
+    ext = ext.lower()
+    if ext not in app.config['ALLOWED_IMG_EXTENSIONS']:
+        return "normal insanlarin kullandigi formatlari kullanirsak..."
+    filename = get_filename(ext)
+    data = file.read()
+    with open(os.path.join(app.config['UPLOAD_FOLDER'], 'o', filename), "wb") as fd:
+        fd.write(data)
+    data = io.BytesIO(data)
+    image = Image.open(data)
+    max_width, max_height = (500, 500)
+    width, height = image.size
+    if width > max_width or height > max_height:
+        width_ratio = max_width / width
+        height_ratio = max_height / height
+        ratio = min(width_ratio, height_ratio)
+        height = height * ratio
+        width = width * ratio
+        try:
+            image = image.resize((int(width), int(height)))
+        except Exception as e:
+            pass
+    return filename;
+
+@app.route('/o/<filename>', methods=['GET'])
+def o(filename):
+    return send_file('o/'+filename, mimetype='image/' + get_extension(filename))
+
+if __name__ == "__main__":
+    app.run(debug=False)

--- a/backend/image/requirements.txt
+++ b/backend/image/requirements.txt
@@ -1,0 +1,2 @@
+flask
+pillow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,12 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres
+
+
+  image:
+    build:
+      context: ./image
+    ports:
+     - "8001:5000"
+    volumes:
+     - ./image:/code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     depends_on:
     - "postgres"
 
+
   postgres:
     image: "postgres"
     ports:
@@ -29,8 +30,8 @@ services:
 
   image:
     build:
-      context: ./image
+      context: ./backend/image
     ports:
      - "8001:5000"
     volumes:
-     - ./image:/code
+     - ./backend/image:/code


### PR DESCRIPTION
This PR provides an additional service to our backend, a new application which is a simply content provider for images. 
It works with a REST api. 
It&quot;s intended use is to have an image hosting service, that is external to our app, which is easier to manage. It is expected from our app to use this service whenever an image is needed to be host. Avatars, listory images etc. are all intended to go into this service.

The applicaiton is written with python/flask. Tested to be running with or without Docker/Docker-compose. 
