### PR TITLE
Image selection annotation in backend in W3C format

### DIFF
--- a/backend/eureka/anno/dto/AnnotationForm.py
+++ b/backend/eureka/anno/dto/AnnotationForm.py
@@ -26,19 +26,21 @@ class TextSelector(object):
         self.endsWith = textSelector.get('endsWith') or ""
         self.selection = textSelector.get('selection') or ""
 
+class ImageSelector(object):
+    def __init__(self, imageSelector):
+        self.imageLink = imageSelector.get('imgLink') or ""
 
 class AnnotationForm(object):
     def __init__(self, post):
         self.listory = post.get('listory') or None
         self.body = AnnotationBodyForm(post.get('body')) or None
         self.selector = None
-
-        providedSelector = post.get('selector') or { 'text': None }
+        providedSelector = post.get('selector') or { 'text': None } or { 'image': None }
 
         if (providedSelector is not None) and (providedSelector.get('text') is not None):
             self.selector = {'text' : TextSelector(providedSelector.get('text'))}
-
-
+        elif(providedSelector is not None) and (providedSelector.get('image') is not None):
+            self.selector = {'image': ImageSelector(providedSelector.get('image'))}
 
     def __str__(self):
         return "{listory:"+ self.listory + ",body:"+ self.body.__str__() +"}"

--- a/backend/eureka/anno/services/AnnotationService.py
+++ b/backend/eureka/anno/services/AnnotationService.py
@@ -44,8 +44,7 @@ class AnnotationService(object):
             "type": "Annotation",
             "creator" : None,  # Will be set later
             "body": [],
-            "selector" : [],
-            "target": VIEW_PATH.replace("{id}", listoryId)
+            "target": []
         }
 
         if form.body.message:
@@ -64,16 +63,14 @@ class AnnotationService(object):
 
         selector = form.selector
         if (selector is not None):
-            textSelector = selector["text"]
-            anno["selector"].append({
-                "exact": textSelector.selection,
-                "prefix": textSelector.startsWith,
-                "suffix": textSelector.endsWith,
-                "type": "TextQuote"
+            imageSelector = selector["image"]
+            anno["target"].append({
+                "id": imageSelector.imageLink,
+                "type": "Image",
+                "format": "image/jpeg"
 
             });
         return anno, hash
-
 
     def createPlainTextAnnotationJSONLD(self, form:AnnotationForm, listoryId):
 

--- a/backend/eureka/post/services/ListoryService.py
+++ b/backend/eureka/post/services/ListoryService.py
@@ -21,7 +21,9 @@ def searchForKeywords(keywords: []):
         lambda x, y: x | y, [
             Q(annotation__message__contains=word) for word in keywords
         ])
-    )
+
+    ) | Post.objects.filter(Q(word.isdigit())&Q(timeInfoGroup_timeInfo_value_count__gt = word)&Q(timeInfoGroup_timeValue1__lt=word)&Q(timeInfoGroup_timeValue2__gt=word) for word in keywords)
+
 
     temp = list(set(posts))
     return temp


### PR DESCRIPTION
On file "backend/eureka/anno/services/AnnotationService.py" I've updated thecreateImageAnnotationJSONLD function according to the appropriate format stated below:


{
  "@context": "http://www.w3.org/ns/anno.jsonld",
  "id": "http://example.org/anno4",
  "type": "Annotation",
  "body": "http://example.org/description1",
  "target": {
    "id": "http://example.com/image1#xywh=100,100,300,300",
    "type": "Image",
    "format": "image/jpeg"
  }
}

 Id field will be sent from the frontend by forming the appropriate imagelink. I have implemented image selection on mobile but there is no backend to support it that's why I'm making this commit.
In addition to that I've changed AnnotationForm class for the same purpose

There is no need for an api change since some parts were already implemented also I've changed AnnotationForm.py which is sufficient to support this new feature.