### PR TITLE
(fix) navigation not updating content fix

### DIFF
--- a/frontend/eureka/src/app/components/search/search.component.html
+++ b/frontend/eureka/src/app/components/search/search.component.html
@@ -4,5 +4,5 @@
   </form>
 
   <div *ngIf="listories" class="list-group" id="search-results">
-      <searchitem *ngFor="let listory of listories" [listory]="listory"></searchitem>
+      <searchitem (onClick)="onClick()" *ngFor="let listory of listories" [listory]="listory"></searchitem>
   </div>

--- a/frontend/eureka/src/app/components/search/search.component.ts
+++ b/frontend/eureka/src/app/components/search/search.component.ts
@@ -18,6 +18,11 @@ export class SearchComponent {
       private searchService: SearchService
   ){}
 
+  onClick(){
+    this.searchString = "";
+    this.searchFor("");
+  }
+
   onSearchStringChange(){
       var currString = this.searchString;
 

--- a/frontend/eureka/src/app/components/search/searchitem/searchitem.component.ts
+++ b/frontend/eureka/src/app/components/search/searchitem/searchitem.component.ts
@@ -1,7 +1,10 @@
 import { Component } from "@angular/core";
-import { Input } from "@angular/core";
+import { Input, Output } from "@angular/core";
 import { Listory } from "../../../services/Listory";
 import { Router } from "@angular/router";
+import { NavigationEnd } from "@angular/router";
+import { EventEmitter } from '@angular/core';
+
 
 @Component({
     selector: "searchitem",
@@ -9,14 +12,28 @@ import { Router } from "@angular/router";
     templateUrl: "searchitem.component.html"
 })
 export class SearchItemComponent {
-    constructor(private router: Router) { }
+    constructor(private router: Router) { 
+         this.router.routeReuseStrategy.shouldReuseRoute = function(){
+        return false;
+     }
 
+
+     this.router.events.subscribe((evt) => {
+        if (evt instanceof NavigationEnd) {
+           this.router.navigated = false;
+           window.scrollTo(0, 0);
+        }
+    });
+    }
 
     @Input() listory: Listory;
 
+    @Output() onClick: EventEmitter<any> = new EventEmitter();
+
 
     gotoItem() {
-        console.log("Navigating to /detail" + this.listory.listoryId);
+        this.router.navigated = false;
+        this.onClick.emit();
         this.router.navigate(['/detail', this.listory.listoryId]);
     }
 }


### PR DESCRIPTION
       Reasons
=====================
1. When navigation occured from search, the contents wasn't updated
properly. Certain elements were missed out.
2. Search should be cleared out if items are clicked.

       Changes
=====================
1. Forced router in searchitem component to force refresh the page to
nothing will be loaded from cache.
2. Added event listeners to searchitem so that search can listen for
clicks, and can clear itself.

       External
=====================
Issue: Selecting an item from search shows incorrect body of Listory #80